### PR TITLE
'jews에 의해 변환된 페이지입니다. 원본 페이지 보기' 메시지를 추가합니다.

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -2062,6 +2062,16 @@ function clearStyles(element) {
     return element;
 }
 
+function unjewsUrl() {
+    var query = window.location.search;
+    if (query.length) {
+        query += '&jews=false';
+    } else {
+        query = '?jews=false';
+    }
+    return window.location.origin + window.location.pathname + query
+}
+
 function reconstruct() {
     (function () {
         var id = window.setTimeout('0', 0);
@@ -2073,9 +2083,13 @@ function reconstruct() {
             '<style>',
             '@import url(http://fonts.googleapis.com/earlyaccess/nanummyeongjo.css);',
             'body {',
-                'margin-top: 50px;',
+                'margin-top: 10px;',
                 'margin-bottom: 500px;',
                 'text-align: center;',
+            '}',
+            '#info {',
+                'margin-bottom: 40px;',
+                'color: #666',
             '}',
             '#meta {',
                 'display: inline-block;',
@@ -2113,6 +2127,12 @@ function reconstruct() {
             '<meta charset="utf-8">',
         '</head>',
         '<body>',
+            '<div id="info">',
+                '<small>',
+                    '<a href="https://github.com/disjukr/jews">jews</a>에 의해 변환된 페이지입니다. ',
+                    '<a href="', unjewsUrl(), '">원본 페이지 보기</a>',
+                '</small>',
+            '</div>',
             '<h1>', jews.title || 'no title', '</h1>',
             (function () {
                 if (jews.subtitle && jews.subtitle !== '') {
@@ -2162,6 +2182,9 @@ function reconstruct() {
 }
 
 function runJews() {
+    if (window.location.search.indexOf('jews=false') > -1) {
+        return;
+    }
     parse(where(window.location.hostname), jews, reconstruct);
 }
 


### PR DESCRIPTION
배경
---

jews를 사용하면서 아래와 같은 니즈가 있었습니다:
- 이 페이지가 jews를 통해 변환된 것인지를 알 수 있으면 좋겠다.
- 원본 페이지로 돌아갈 수 있으면 좋겠다.


작동 원리
-------

'원본 페이지 보기'를 클릭하면 현재 URL의 쿼리스트링에 `jews=false` 파라미터가 추가되어 리디렉션됩니다. `runJews()`에서 `jews=false` 쿼리스트링이 포함되어있으면 페이지를 변환하지 않습니다.


적용 예시
-------

![screen shot 2015-01-04 at 5 55 43 pm](https://cloud.githubusercontent.com/assets/931655/5605378/edca0556-943a-11e4-9f5b-28f33a62d90a.png)
