### PR TITLE
연합뉴스 일부 페이지에서 타이틀을 제대로 가져오지 못하는 버그 수정

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -1244,7 +1244,7 @@ parse['아이뉴스24'] = function (jews) {
     };
 };
 parse['연합뉴스'] = function (jews) {
-    jews.title = $('#articleWrap h2').text();
+    jews.title = $('#articleWrap h2').text() || $('#articleWrap h1').text() || undefined;
     jews.subtitle = $('.article .stit strong b').text() || undefined;
     jews.content = (function () {
         var content = $('.article')[0].cloneNode(true);


### PR DESCRIPTION
연합뉴스 제목 들어가는 엘리먼트가 `<h2>` 일때도 있고 `<h1>` 일때도 있어서 둘 다 가져오도록 수정.

문제 페이지:
* http://www.yonhapnews.co.kr/society/2015/01/15/0701000000AKR20150115016200054.HTML
* http://www.yonhapnews.co.kr/society/2015/01/15/0702000000AKR20150115052300004.HTML