### PR TITLE
Youtube size fix for 블로터닷넷

### DIFF
--- a/jews.user.js
+++ b/jews.user.js
@@ -1241,6 +1241,16 @@ parse['블로터닷넷'] = function (jews) {
     jews.title = document.title;
     jews.subtitle = undefined;
     jews.content = (function () {
+        // Youtube Size Fix.
+        $('iframe').each(function (index) {
+            var iframe = $($("iframe")[index]);
+            var width = parseInt(iframe.attr("width"));
+            var height = parseInt(iframe.attr("height"));
+            if (iframe.attr("src").indexOf("youtube") != -1 && width > 640) {
+                iframe.attr("width", 640).attr("height", 640 / width * height);
+            }
+        });
+        
         var content = $('.pf-content')[0].cloneNode(true);
         $('.printfriendly', content).remove();
         return clearStyles(content).innerHTML;


### PR DESCRIPTION
I fixed youtube size for bloter.net.

Before
<img width="1073" alt="2015-10-02 11 28 36" src="https://cloud.githubusercontent.com/assets/1115741/10238302/c5aefcdc-68f8-11e5-82ba-c6b763b92da2.png">

After
<img width="657" alt="2015-10-02 11 28 27" src="https://cloud.githubusercontent.com/assets/1115741/10238300/c56b028e-68f8-11e5-930a-af09e648e3ed.png">