### PR TITLE
dist 디렉토리를 gitignore에 등록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+dist


### PR DESCRIPTION
사람이 커밋할때 `git add .`같은 짓거리를 한다던가 하면 dist를 강제로 업로드할 위험성이 있는 것 같습니다.

ignore에 넣어놓고 필요할때만 직업 올리면 될 것 같습니다