### PR TITLE
머니투데이 잘못된 작성일 수정

### DIFF
--- a/src/impl/머니투데이.js
+++ b/src/impl/머니투데이.js
@@ -16,7 +16,7 @@ export default function () {
         return clearStyles(content).innerHTML;
     })();
     jews.timestamp = {
-        created: new Date($('.infobox1 .num').text().replace(": ", "").replace(/\./g, '/')), // ": 2014.06.20 06:31"형태로 들어있음
+        created: new Date($('.infobox1 .num:first').text().replace(": ", "").replace(/\./g, '/')), // ": 2014.06.20 06:31"형태로 들어있음
         lastModified: undefined
     };
     jews.reporters = (function () {

--- a/src/test/suite/basic.js
+++ b/src/test/suite/basic.js
@@ -53,7 +53,7 @@ describe('날짜 파싱에 실패하면 안됨', function () {
         await testTimestampParsing('http://www.mydaily.co.kr/new_yk/html/read.php?newsid=201511192101592220&ext=na'); // #208
     });
     it('머니투데이', async () => {
-        await testTimestampParsing('http://news.mt.co.kr/mtview.php?no=2016011710375658661&MT'); // #
+        await testTimestampParsing('http://news.mt.co.kr/mtview.php?no=2016011710375658661&MT'); // #229
     });
 });
 

--- a/src/test/suite/basic.js
+++ b/src/test/suite/basic.js
@@ -52,6 +52,9 @@ describe('날짜 파싱에 실패하면 안됨', function () {
     it('마이데일리', async () => {
         await testTimestampParsing('http://www.mydaily.co.kr/new_yk/html/read.php?newsid=201511192101592220&ext=na'); // #208
     });
+    it('머니투데이', async () => {
+        await testTimestampParsing('http://news.mt.co.kr/mtview.php?no=2016011710375658661&MT'); // #
+    });
 });
 
 


### PR DESCRIPTION
`.infobox1` 안에 조회수 div 태그에 num 클래스가 붙으면서 `$('.infobox1 .num').text()` 결과가 변경되어 파싱이 잘못됨.

fixes #229 